### PR TITLE
Fix path setting

### DIFF
--- a/brief/services/BriefService.php
+++ b/brief/services/BriefService.php
@@ -109,7 +109,7 @@ class BriefService extends BaseApplicationComponent
 			'siteName' => craft()->getSiteName(),
 			'cpEditUrl' => UrlHelper::getCpUrl(),
 			'sectionTitle' => $entry->section->name,
-			'entryUrl' => craft()->getSiteUrl() . $this->entryUri,
+			'entryUrl' => craft()->getSiteUrl() . $entry->uri,
 		];
 
 		return craft()->templates->render('brief/email', $variables);


### PR DESCRIPTION
Hey Taylor, was this what you were hoping to achieve? I noticed the notification email was coming through fine, but there wasn't actually a link to the entry, just the root URL. Then I saw that `$this->entryUrl` was never actually being set. Easily fix since `$entry` is being passed into the function.
