### PR TITLE
Hard coded "News" section

### DIFF
--- a/brief/templates/email.html
+++ b/brief/templates/email.html
@@ -171,7 +171,7 @@
 						<tr>
 							<td style="border-collapse: collapse;">
 								<span style="font-size: 19px; line-height: 28px; font-family: Helvetica; color: #242424;">
-                  Hey, there! There's been an update or addition to the <span style="font-weight: bold;">{{ sectionTitle }}</span> Section. You can see it on your site <a href="{{ entryUrl }}" style="color: #E15718;">here</a>.
+                  							Hey, there! There's been an update or addition to the <span style="font-weight: bold;">{{ sectionTitle }}</span> Section. You can see it on your site <a href="{{ entryUrl }}" style="color: #E15718;">here</a>.
 								</span>
 							</td>
 						</tr>

--- a/brief/templates/email.html
+++ b/brief/templates/email.html
@@ -171,7 +171,7 @@
 						<tr>
 							<td style="border-collapse: collapse;">
 								<span style="font-size: 19px; line-height: 28px; font-family: Helvetica; color: #242424;">
-									Hey, there! There's been an update or addition to the <span style="font-weight: bold;">News</span> Section. You can see it on your site <a href="{{ entryUrl }}" style="color: #E15718;">here</a>.
+                  Hey, there! There's been an update or addition to the <span style="font-weight: bold;">{{ sectionTitle }}</span> Section. You can see it on your site <a href="{{ entryUrl }}" style="color: #E15718;">here</a>.
 								</span>
 							</td>
 						</tr>


### PR DESCRIPTION
Hello! 

I noticed that in the email template, the section was hard coded to "News." I replaced that hard coded text and put in the `sectionTitle` variable.

Thanks,
Ian
