### PR TITLE
Allow custom email notification template to be defined in the settings.

### DIFF
--- a/brief/BriefPlugin.php
+++ b/brief/BriefPlugin.php
@@ -123,6 +123,7 @@ Class BriefPlugin extends BasePlugin
 			'trigger_section' => array(AttributeType::Mixed, 'default' => ''),
 			'user_group' => array(AttributeType::Mixed, 'default' => ''),
 			'slack_webhook' => array(AttributeType::String, 'default' => ''),
+            'email_template' => array(AttributeType::String, 'default' => ''),
 			'subject' => array(AttributeType::Mixed, 'default' => $defaultSubject),
 		);
 	}

--- a/brief/services/BriefService.php
+++ b/brief/services/BriefService.php
@@ -95,14 +95,31 @@ class BriefService extends BaseApplicationComponent
 
 	public function generateBody($entry)
 	{
+		// was a custom email template defined?
+		if ('' !== $this->settings->email_template) {
+			$emailTemplate = $this->settings->email_template;
+			// if a custom email template was set we need to update the templates library to use the site templates
+			craft()->templates->setTemplateMode(TemplateMode::Site);
+		} else {
+			$emailTemplate = 'brief/email';
+		}
+
 		$variables = [
 			'siteName' => craft()->getSiteName(),
 			'cpEditUrl' => UrlHelper::getCpUrl(),
+            'entry' => $entry,
 			'sectionTitle' => $entry->section->name,
 			'entryUrl' => craft()->getSiteUrl() . $entry->uri,
 		];
 
-		return craft()->templates->render('brief/email', $variables);
+		$generatedBody = craft()->templates->render($emailTemplate, $variables);
+
+		// if a custom template was defined we need to set the template library back to CP when we're done
+		if ('' !== $this->settings->email_template) {
+			craft()->templates->setTemplateMode(TemplateMode::CP);
+		}
+
+		return $generatedBody;
 	}
 
 	public function notifySlack($entry)

--- a/brief/templates/settings.html
+++ b/brief/templates/settings.html
@@ -21,3 +21,13 @@
 
 	})
 }}
+
+{{
+	forms.textField({
+		label: "Email Template",
+		instructions: "Enter a custom Twig template to render for email notification.",
+		name: 'email_template',
+		value: settings.email_template
+
+	})
+}}


### PR DESCRIPTION
We had a need to override the email notification template in a project and use more properties of the Entry object while generating the content.

Hopefully this might be useful to consider for a future release :) .